### PR TITLE
query-jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ While node will mostly deal with things asynchronously, Haven OnDemand offers se
 client.call('analyzesentiment', data, callback, true)
 ```
 
+**Querying jobs from async calls**
+
+When you create a job asynchronously, you will get a jobID returned as ```body.data.jobID```. You can then query this job to get it status and eventually the result. You can see the API here: [docs/AsynchronousAPI](https://dev.havenondemand.com/docs/AsynchronousAPI.htm). You use the same ```client.call``` method to query jobs by adding ```jobID``` & ```method``` to the ```data``` object.
+
+```js
+client.call('job', {jobID: <jobID>, type: 'status'}, callback); // get the status of the job, including results if the job is finished.
+
+client.call('job', {jobID: <jobID>, type: 'result'}, callback); // waits until the job has finished and then returns the result.
+```
+
 ### Posting files
 
 File posting is handled using the "file" parameter name which is used for all current file postings in Haven OnDemand

--- a/lib/hodneedle.js
+++ b/lib/hodneedle.js
@@ -11,6 +11,7 @@ function HODClient(apikey,version) {
   else {this.version=version;}
   this.apikey = apikey;
   this.endpoint = "https://api.havenondemand.com/1/api/%s/%s/"+this.version;
+  this.endpointJob = "https://api.havenondemand.com/1/%s/%s/%s";
 }
 // class methods
 
@@ -55,7 +56,13 @@ HODClient.prototype.call = function(handler,arg1,arg2,arg3) {
     async_string="async";
   }
 
-  var url = util.format(this.endpoint,async_string,handler);
+  if (data.jobID && handler === "job" && (data.method === "status" || data.method === "result")) {
+    var url = util.format(this.endpointJob,handler,data.method,data.jobID);
+    delete data.jobID;
+    delete data.method;
+  } else {
+    var url = util.format(this.endpoint,async_string,handler);
+  }
   //console.log(url)
 
   if (typeof callback == "undefined") {


### PR DESCRIPTION
- Added functionality to query jobs with either 'status' or 'result', as per this doc: https://dev.havenondemand.com/docs/AsynchronousAPI.htm
- Updated the readme to reflect these updates
